### PR TITLE
Format files using the "Terraform (variables)" syntax as well

### DIFF
--- a/terrafmt.py
+++ b/terrafmt.py
@@ -105,7 +105,7 @@ class TerrafmtCommand(sublime_plugin.TextCommand):
 
 		:returns: bool
 		'''
-		return self.view.score_selector(0, 'source.terraform') != 0
+		return any(self.view.score_selector(0, i) for i in ['source.terraform', 'source.terraform-vars'])
 
 	def run(self, edit):
 		'''


### PR DESCRIPTION
The new syntax was added in version 1.2.0 of the Terraform plugin for Sublime
Text: https://github.com/alexlouden/Terraform.tmLanguage/releases/tag/1.2.0.